### PR TITLE
Use parameter path based api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ dockerfy -- Utility to initialize docker containers
 **Dockerfy** is a utility program to initialize and control container applications, and also provide some
 missing OS functionality (such as an init process, and reaping zombies etc.)
 
+### Open Source
+Dockerfy is an open-source project under Apache 2.0 license.  This clone is up to date, but the official source has now moved to [SocialCodeInc/dockerfy](https://github.com/SocialCodeInc/dockerfy/)
 
 ##Key Features
 

--- a/README.md
+++ b/README.md
@@ -166,16 +166,19 @@ For convenience, all secrets files are combined into ~/.secrets/combined_secrets
 container for each `--user` account in the users home directory so the program running as the user will have permission to read the values and so JavaScript, Python and Go programs can load the secrets programatically from a single file.  The combined secrets file location is exported as $SECRETS_FILE into the running --start, --run and primary command's environments.
 
 #### Loading Secret Settings from AWS Systems Manager Parameter Store
-Secrets can be stored in the AWS Systems Manager [Parameter Store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
-If you specify an expression like  {{ .AWS_Secret.**VARNAME** }} in a template then dockerfy will query the AWS Parameter store.
+Dcokerfy can also load secrets stored in the AWS Systems Manager [Parameter Store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
+If you specify an expression like `{{ .AWS_Secret.**VARNAME** }}` in a template then dockerfy will fetch parameters from the AWS Parameter store.
 It can retrieve the decoded values of at most 10 parameters. 
-Further you can specify a prefix (--aws-secret-prefix PPP). 
-This allows you n have multiple parameters in the Parameter Store with different prefixes...
 
-	PROD_DB_PASSWORD = xxx
-        TEST_DB_PASSWORD = yyy
+If you store multiple parameters in the Parameter Store with different prefixes, for example for production and test:
 
-... and you can select a specific parameter by specifying `--aws-secret-prefix PROD_` and using {{ .AWS_Secret.**DB_PASSWORD** }} in your template.
+    PROD_DB_PASSWORD = xxx
+    TEST_DB_PASSWORD = yyy
+
+Dockerfy will select a specific parameter that matches the prefix given with option `--aws-secret-prefix PROD_`. You can use `{{ .AWS_Secret.**DB_PASSWORD** }}` in your template,
+thus without the prefix.
+
+If dockerfy cannot access a parameter it fall back to using the value of an corerspoding ENVIRONMENT value.
 
 
 ##### Security Concerns

--- a/README.md
+++ b/README.md
@@ -167,18 +167,17 @@ container for each `--user` account in the users home directory so the program r
 
 #### Loading Secret Settings from AWS Systems Manager Parameter Store
 Dcokerfy can also load secrets stored in the AWS Systems Manager [Parameter Store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
-If you specify an expression like `{{ .AWS_Secret.**VARNAME** }}` in a template then dockerfy will fetch parameters from the AWS Parameter store.
-It can retrieve the decoded values of at most 10 parameters. 
+If you specify an expression like `{{ .AWS_Secret.**VARNAME** }}` in a template then dockerfy will try to fetch the parameter from the AWS Parameter store.
+If the parameter cannot be found (due to lack or permission or because it does not exist) dockerfy falls back to using the value of a corresponding ENVIRONMENT value.
+Dockerfy retrieves the decoded values of at most 10 parameters. 
 
-If you store multiple parameters in the Parameter Store with different prefixes, for example for production and test:
+You can store multiple parameters in the Parameter Store with different prefixes. For example, for production and test:
 
     PROD_DB_PASSWORD = xxx
     TEST_DB_PASSWORD = yyy
 
-Dockerfy will select a specific parameter that matches the prefix given with option `--aws-secret-prefix PROD_`. You can use `{{ .AWS_Secret.**DB_PASSWORD** }}` in your template,
-thus without the prefix.
-
-If dockerfy cannot access a parameter it fall back to using the value of an corerspoding ENVIRONMENT value.
+To select a specific parameter that matches the prefix specify option `--aws-secret-prefix PROD_`. 
+You can use `{{ .AWS_Secret.**DB_PASSWORD** }}` in your template, thus without the prefix.
 
 
 ##### Security Concerns

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If the source path ends with a /, then all subdirectories underneath it will be 
 Overlay sources that do not exist are simply skipped.  The allows you to specify potential sources of content that may or may not exist in the running container.  In the above example if $DEPLOYMENT_ENV environment variable is set to 'local' then the second overlaw will be skipped if there is no corresponding /app/overlays/local source directory, and the container will run with the '_common' html content.
 
 #### Loading Secret Settings
-Secrets can loaded from files by using the `--secrets-files` option or the $SECRETS_FILES environment variable.   The secrets files ending with `.env` must contain simple NAME=VALUE lines, following bash shell conventions for definitions and comments. Leading and trailing quotes will be trimmed from the value.  Secrets files ending with `.json` will be loaded as JSON, and must be `a simple single-level dictionary of strings`
+Secrets can be loaded from files by using the `--secrets-files` option or the $SECRETS_FILES environment variable.   The secrets files ending with `.env` must contain simple NAME=VALUE lines, following bash shell conventions for definitions and comments. Leading and trailing quotes will be trimmed from the value.  Secrets files ending with `.json` will be loaded as JSON, and must be `a simple single-level dictionary of strings`
 
     #
     # These are our secrets
@@ -166,10 +166,10 @@ For convenience, all secrets files are combined into ~/.secrets/combined_secrets
 container for each `--user` account in the users home directory so the program running as the user will have permission to read the values and so JavaScript, Python and Go programs can load the secrets programatically from a single file.  The combined secrets file location is exported as $SECRETS_FILE into the running --start, --run and primary command's environments.
 
 #### Loading Secret Settings from AWS Systems Manager Parameter Store
-Dcokerfy can also load secrets stored in the AWS Systems Manager [Parameter Store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
+**Dockerfy** can also load secrets stored in the AWS Systems Manager [Parameter Store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
 If you specify an expression like `{{ .AWS_Secret.**VARNAME** }}` in a template then dockerfy will try to fetch the parameter from the AWS Parameter store.
 If the parameter cannot be found (due to lack or permission or because it does not exist) dockerfy falls back to using the value of a corresponding ENVIRONMENT value.
-Dockerfy retrieves the decoded values of at most 10 parameters. 
+**Dockerfy** retrieves the decoded values of at most 10 parameters. 
 
 You can store multiple parameters in the Parameter Store with different prefixes. For example, for production and test:
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ You can specify multiple secrets files by using a colon to separate the paths, o
 For convenience, all secrets files are combined into ~/.secrets/combined_secrets.json inside the ephemeral running
 container for each `--user` account in the users home directory so the program running as the user will have permission to read the values and so JavaScript, Python and Go programs can load the secrets programatically from a single file.  The combined secrets file location is exported as $SECRETS_FILE into the running --start, --run and primary command's environments.
 
+#### Loading Secret Settings from AWS Systems Manager Parameter Store
+Secrets can be stored in the AWS Systems Manager [Parameter Store](https://aws.amazon.com/ec2/systems-manager/parameter-store/).
+If you specify an expression like  {{ .AWS_Secret.**VARNAME** }} in a template then dockerfy will query the AWS Parameter store.
+It can retrieve the decoded values of at most 10 parameters. 
+Further you can specify a prefix (--aws-secret-prefix PPP). 
+This allows you n have multiple parameters in the Parameter Store with different prefixes...
+
+	PROD_DB_PASSWORD = xxx
+        TEST_DB_PASSWORD = yyy
+
+... and you can select a specific parameter by specifying `--aws-secret-prefix PROD_` and using {{ .AWS_Secret.**DB_PASSWORD** }} in your template.
+
+
 ##### Security Concerns
 1. **Reading secrets from files** -- Dockerfy only passes secrets to programs via configuration files to prevent leakage. Secrets could be passed to programs via the environment, but programs use the environment in unpredictable ways, such as logging, or perhaps even dumping their state back to the browser.
 2. **Installing Secrets** -- The recommended way to install secrets in production environments is to save them to a tightly protected place on the host and then mount that directory into running docker containers that need secrets. Yes, this is host-level security, but at this point in time, if the host running the docker daemon is not secure, then security has already been compromised.

--- a/aws_secrets.go
+++ b/aws_secrets.go
@@ -25,7 +25,8 @@ func getAWS_Secrets() map[string]string {
         if err != nil {
           return GetEnvMap()
         }
-        filtered := filterNames(parameterNames, awsSecretsPrefixFlag)
+        prefix := string_template_eval(awsSecretsPrefixFlag)
+        filtered := filterNames(parameterNames, prefix)
         if len(filtered) == 0 {
           return GetEnvMap()
         }
@@ -36,9 +37,10 @@ func getAWS_Secrets() map[string]string {
 func asMap(parameters *ssm.GetParametersOutput) map[string]string {
 
 	secrets := GetEnvMap() 
+        prefix := string_template_eval(awsSecretsPrefixFlag)
 	for i := 0; i < len(parameters.Parameters); i++ {
 		name := *parameters.Parameters[i].Name
-                name = strings.Replace(name, awsSecretsPrefixFlag, "", 1)
+                name = strings.Replace(name, prefix, "", 1)
 		secrets[name] = *parameters.Parameters[i].Value
 	}
 	return secrets

--- a/aws_secrets.go
+++ b/aws_secrets.go
@@ -25,7 +25,8 @@ func getAWS_Secrets() map[string]string {
         if err != nil {
           return GetEnvMap()
         }
-   	secrets := fetchAWS_Secrets(svc,parameterNames)
+        filtered := filterNames(parameterNames, awsSecretsPrefixFlag)
+   	secrets := fetchAWS_Secrets(svc,filtered)
 	return asMap(secrets)
 }
 
@@ -34,7 +35,7 @@ func asMap(parameters *ssm.GetParametersOutput) map[string]string {
 	secrets := GetEnvMap() 
 	for i := 0; i < len(parameters.Parameters); i++ {
 		name := *parameters.Parameters[i].Name
-		name = strings.Replace(name, awsSecretsPrefixFlag, "", 1)
+                name = strings.Replace(name, awsSecretsPrefixFlag, "", 1)
 		secrets[name] = *parameters.Parameters[i].Value
 	}
 	return secrets
@@ -51,6 +52,18 @@ func fetchAWS_Secrets(svc *ssm.SSM, parameterNames []string) *ssm.GetParametersO
 		log.Fatalf("cannot fetch AWS System Manager Parameters %s", err.Error())
 	}
 	return resp
+}
+
+
+func filterNames(input []string, prefix string) []string {
+	size := len(input)
+        var output []string
+        for i := 0; i < size; i++ {
+                if strings.HasPrefix(input[i], prefix) {
+                        output = append(output, input[i])
+                }
+        }
+        return output
 }
 
 func describeAWS_ParameterNames(svc *ssm.SSM) ([]string,error) {

--- a/aws_secrets.go
+++ b/aws_secrets.go
@@ -26,6 +26,9 @@ func getAWS_Secrets() map[string]string {
           return GetEnvMap()
         }
         filtered := filterNames(parameterNames, awsSecretsPrefixFlag)
+        if len(filtered) == 0 {
+          return GetEnvMap()
+        }
    	secrets := fetchAWS_Secrets(svc,filtered)
 	return asMap(secrets)
 }

--- a/aws_secrets.go
+++ b/aws_secrets.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+//
+// return a map of AWS secrets (from AWS System Manager Parameter Store)
+//
+func getAWS_Secrets() map[string]string {
+
+	sess := session.Must(session.NewSession())
+	svc := ssm.New(sess)
+
+	secrets := fetchAWS_Secrets(svc, describeAWS_ParameterNames(svc))
+	return asMap(secrets)
+}
+
+func asMap(parameters *ssm.GetParametersOutput) map[string]string {
+
+	secrets := make(map[string]string)
+	for i := 0; i < len(parameters.Parameters); i++ {
+		name := *parameters.Parameters[i].Name
+		name = strings.Replace(name, awsSecretsPrefixFlag, "", 1)
+		secrets[name] = *parameters.Parameters[i].Value
+	}
+	return secrets
+}
+
+func fetchAWS_Secrets(svc *ssm.SSM, parameterNames []string) *ssm.GetParametersOutput {
+	params := &ssm.GetParametersInput{
+		Names:          aws.StringSlice(parameterNames),
+		WithDecryption: aws.Bool(true),
+	}
+	resp, err := svc.GetParameters(params)
+
+	if err != nil {
+		log.Fatalf("cannot fetch AWS System Manager Parameters %s", err.Error())
+	}
+	return resp
+}
+
+func describeAWS_ParameterNames(svc *ssm.SSM) []string {
+	criteria := &ssm.DescribeParametersInput{
+		MaxResults: aws.Int64(10), // limited by API call GetParametersInput
+	}
+	resp, err := svc.DescribeParameters(criteria)
+	if err != nil {
+		log.Fatalf("cannot describe AWS Parameter Names %s", err.Error())
+	}
+
+	size := len(resp.Parameters)
+	names := make([]string, size)
+
+	for i := 0; i < size; i++ {
+		names[i] = *resp.Parameters[i].Name
+	}
+
+	return names
+}

--- a/aws_secrets.go
+++ b/aws_secrets.go
@@ -73,7 +73,7 @@ func filterNames(input []string, prefix string) []string {
 
 func describeAWS_ParameterNames(svc *ssm.SSM) ([]string,error) {
 	criteria := &ssm.DescribeParametersInput{
-		MaxResults: aws.Int64(10), // limited by API call GetParametersInput
+		MaxResults: aws.Int64(45), // limited by API call GetParametersInput
 	}
 	resp, err := svc.DescribeParameters(criteria)
 	if err != nil {

--- a/dockerfy.go
+++ b/dockerfy.go
@@ -45,14 +45,14 @@ var (
 	reapFlag             bool
 	runsFlag             sliceVar
 	secretsFilesFlag     sliceVar
-	awsSecretsPrefixFlag        string
+	awsSecretsPrefixFlag string
 	startsFlag           sliceVar
 	stderrTailFlag       sliceVar
 	stdoutTailFlag       sliceVar
 	templatesFlag        sliceVar
 	usersFlag            sliceVar
-    verboseFlag          bool
-    debugFlag            bool
+	verboseFlag          bool
+	debugFlag            bool
 	versionFlag          bool
 	waitFlag             hostFlagsVar
 	waitTimeoutFlag      time.Duration
@@ -131,7 +131,7 @@ Arguments:
 	     `)
 	println(`   Retrieve parameters with a given prefix from AWS Parameter store and use them in a template:
 
-       dockerfy --aws-secret-prefix PRODUCTION /bin/echo '{{ AWS_Secret.password }}'
+       dockerfy --aws-secret-prefix PRODUCTION /bin/echo '{{ .AWS_Secret.password }}'
 	     `)
 	println(`For more information, see https://github.com/markriggins/dockerfy `)
 }
@@ -158,8 +158,8 @@ func main() {
 	flag.Var(&runsFlag, "run", "run (cmd [opts] [args] --) Can be passed multiple times")
 	flag.Var(&startsFlag, "start", "start (cmd [opts] [args] --) Can be passed multiple times")
 	flag.BoolVar(&reapFlag, "reap", false, "reap all zombie processes")
-    flag.BoolVar(&verboseFlag, "verbose", false, "verbose output")
-    flag.BoolVar(&debugFlag, "debug", false, "debugging output")
+	flag.BoolVar(&verboseFlag, "verbose", false, "verbose output")
+	flag.BoolVar(&debugFlag, "debug", false, "debugging output")
 	flag.Var(&stdoutTailFlag, "stdout", "Tails a file to stdout. Can be passed multiple times")
 	flag.Var(&stderrTailFlag, "stderr", "Tails a file to stderr. Can be passed multiple times")
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
@@ -167,16 +167,16 @@ func main() {
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout duration, defaults to 10s")
 	flag.DurationVar(&reapPollIntervalFlag, "reap-poll-interval", 120*time.Second, "Polling interval for reaping zombies")
 
-    // Manually pre-process the --debug and --verbose flags so we can debug our complex argument pre-processing
-    // that happens BEFORE flag.Parse()
-    for i := 0; i < len(os.Args); i++ {
-        if strings.TrimSpace(os.Args[i]) == "--debug" {
-            debugFlag = true
-            log.Printf("debugging output ..")
-        } else if strings.TrimSpace(os.Args[i]) == "--verbose" {
-            verboseFlag = true
-        }
-    }
+	// Manually pre-process the --debug and --verbose flags so we can debug our complex argument pre-processing
+	// that happens BEFORE flag.Parse()
+	for i := 0; i < len(os.Args); i++ {
+		if strings.TrimSpace(os.Args[i]) == "--debug" {
+			debugFlag = true
+			log.Printf("debugging output ..")
+		} else if strings.TrimSpace(os.Args[i]) == "--verbose" {
+			verboseFlag = true
+		}
+	}
 
 	var commands = removeCommandsFromOsArgs()
 
@@ -208,9 +208,9 @@ func main() {
 
 	// Overlay files from src --> dst
 	for _, o := range overlaysFlag {
-        if debugFlag {
-            log.Printf("--overlay: %s", o)
-        }
+		if debugFlag {
+			log.Printf("--overlay: %s", o)
+		}
 		if strings.Contains(o, ":") {
 			parts := strings.Split(o, ":")
 			if len(parts) != 2 {
@@ -281,10 +281,10 @@ func main() {
 			}
 		}, cmd, false /*cancel_when_finished*/)
 		wg.Wait()
-        if exitCode != 0 {
-            cancel()
-            os.Exit(exitCode)
-        }
+		if exitCode != 0 {
+			cancel()
+			os.Exit(exitCode)
+		}
 	}
 
 	for _, logFile := range stdoutTailFlag {
@@ -341,7 +341,7 @@ func main() {
 			cancel()
 		}, primary_command, true /*cancel_when_finished*/)
 
-        //TODO -- catch signals and log the fact that dockerfy itself was terminated
+		//TODO -- catch signals and log the fact that dockerfy itself was terminated
 	} else {
 		cancel()
 	}

--- a/dockerfy.go
+++ b/dockerfy.go
@@ -45,6 +45,7 @@ var (
 	reapFlag             bool
 	runsFlag             sliceVar
 	secretsFilesFlag     sliceVar
+	awsSecretsPrefixFlag        string
 	startsFlag           sliceVar
 	stderrTailFlag       sliceVar
 	stdoutTailFlag       sliceVar
@@ -128,6 +129,10 @@ Arguments:
 
        dockerfy --start /bin/sleep 5 -- /bin/service
 	     `)
+	println(`   Retrieve parameters with a given prefix from AWS Parameter store and use them in a template:
+
+       dockerfy --aws-secret-prefix PRODUCTION /bin/echo '{{ AWS_Secret.password }}'
+	     `)
 	println(`For more information, see https://github.com/markriggins/dockerfy `)
 }
 
@@ -149,6 +154,7 @@ func main() {
 	flag.Var(&templatesFlag, "template", "Template (/template:/dest). Can be passed multiple times")
 	flag.Var(&overlaysFlag, "overlay", "overlay (/src:/dest). Can be passed multiple times")
 	flag.Var(&secretsFilesFlag, "secrets-files", "secrets files (path to secrets.env files). Colon-separated list")
+	flag.StringVar(&awsSecretsPrefixFlag, "aws-secret-prefix", "", "Prefix for Secrets stored in the AWS Systems Manager Parameter Store")
 	flag.Var(&runsFlag, "run", "run (cmd [opts] [args] --) Can be passed multiple times")
 	flag.Var(&startsFlag, "start", "start (cmd [opts] [args] --) Can be passed multiple times")
 	flag.BoolVar(&reapFlag, "reap", false, "reap all zombie processes")

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: f7c96fff6dfa8e27fee8c4885fc2afd882dcc13ee2892d613a863cd59724605b
-updated: 2017-03-15T12:52:02.768149871+01:00
+hash: 936f1f83eb24c5d23d1e7e462142cbcf3dd2561d622294e5e16746e042e2d779
+updated: 2018-06-18T16:51:15.764139+02:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 62c16d8bf2fd6ee59f2bf11ae8268d045470ccf6
+  version: efab853f45fc7a963059adbd2d552f828684afd4
   subpackages:
   - aws
   - aws/awserr
@@ -14,12 +14,16 @@ imports:
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
   - aws/credentials/stscreds
+  - aws/csm
   - aws/defaults
   - aws/ec2metadata
   - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkio
+  - internal/sdkrand
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
@@ -28,30 +32,30 @@ imports:
   - private/protocol/rest
   - private/protocol/xml/xmlutil
   - service/ssm
+  - service/ssm/ssmiface
   - service/sts
-  - services/ssm
   - session
 - name: github.com/go-ini/ini
-  version: 98c45284d68a05a0e0a576de574bd975946ef9ad
+  version: cec2bdc49009247305a260b082a18e802d0fe292
 - name: github.com/hpcloud/tail
-  version: a30252cb686a21eb2d0b98132633053ec2f7f1e5
+  version: a1dbeea552b7c8df4b542c66073e393de198a800
   subpackages:
   - ratelimiter
   - util
   - watch
   - winfile
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: golang.org/x/net
-  version: ffe101cce3477a6c6d8f0754d103bb0a84ec1266
+  version: db08ff08e8622530d9ed3a0e8ac279f6d4c02196
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 6c888cc515d3ed83fc103cf1d84468aad274b0a7
   subpackages:
   - unix
-- name: gopkg.in/fsnotify.v1
-  version: 7be54206639f256967dd82fa767397ba5f8f48f5
+- name: gopkg.in/fsnotify/fsnotify.v1
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/tomb.v1
   version: c131134a1947e9afd9cecfe11f4c6dff0732ae58
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,38 @@
-hash: b3ee1b2fbddde827859f48dbe566d88657d373bad19cd0290ad4483f88ddf04e
-updated: 2016-10-05T09:13:41.371137555-04:00
+hash: f7c96fff6dfa8e27fee8c4885fc2afd882dcc13ee2892d613a863cd59724605b
+updated: 2017-03-15T12:52:02.768149871+01:00
 imports:
-- name: github.com/golang/lint
-  version: 55ae771cfa82f3846897c972e262ed5d54d47d48
+- name: github.com/aws/aws-sdk-go
+  version: 62c16d8bf2fd6ee59f2bf11ae8268d045470ccf6
   subpackages:
-  - golint
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - private/protocol
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - service/ssm
+  - service/sts
+  - services/ssm
+  - session
+- name: github.com/go-ini/ini
+  version: 98c45284d68a05a0e0a576de574bd975946ef9ad
 - name: github.com/hpcloud/tail
   version: a30252cb686a21eb2d0b98132633053ec2f7f1e5
   subpackages:
@@ -12,6 +40,8 @@ imports:
   - util
   - watch
   - winfile
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: golang.org/x/net
   version: ffe101cce3477a6c6d8f0754d103bb0a84ec1266
   subpackages:
@@ -24,4 +54,4 @@ imports:
   version: 7be54206639f256967dd82fa767397ba5f8f48f5
 - name: gopkg.in/tomb.v1
   version: c131134a1947e9afd9cecfe11f4c6dff0732ae58
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,13 +1,14 @@
+---
 package: github.com/SocialCodeInc/dockerfy
 import:
-- package: github.com/hpcloud/tail
-- package: github.com/aws/aws-sdk-go
-  subpackages:
-  - services/ssm
-  - session
-- package: golang.org/x/net
-  subpackages:
-  - context
-- package: golang.org/x/sys
-  subpackages:
-  - unix
+  - package: github.com/hpcloud/tail
+  - package: github.com/aws/aws-sdk-go
+    subpackages:
+      - service/ssm
+      - session
+  - package: golang.org/x/net
+    subpackages:
+      - context
+  - package: golang.org/x/sys
+    subpackages:
+      - unix

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,10 @@
 package: github.com/SocialCodeInc/dockerfy
 import:
 - package: github.com/hpcloud/tail
+- package: github.com/aws/aws-sdk-go
+  subpackages:
+  - services/ssm
+  - session
 - package: golang.org/x/net
   subpackages:
   - context

--- a/template.go
+++ b/template.go
@@ -18,12 +18,12 @@ type TemplateContext struct {
 }
 
 func GetEnvMap() map[string]string {
-    env := make(map[string]string)
-    for _, i := range os.Environ() {
-        sep := strings.Index(i, "=")
-        env[i[0:sep]] = i[sep+1:]
-    }
-    return env
+	env := make(map[string]string)
+	for _, i := range os.Environ() {
+		sep := strings.Index(i, "=")
+		env[i[0:sep]] = i[sep+1:]
+	}
+	return env
 }
 
 //
@@ -32,7 +32,7 @@ func GetEnvMap() map[string]string {
 // '{{concat "P" "WD" | getenv}}' will print $PWD
 //
 func GetEnv(v string) string {
-    return GetEnvMap()[v]
+	return GetEnvMap()[v]
 }
 
 //
@@ -58,13 +58,12 @@ func (c *TemplateContext) Secret() map[string]string {
 }
 
 func (c *TemplateContext) AWS_Secret() map[string]string {
-        if c.aws_secrets != nil {
-                return c.aws_secrets
-        }
-        c.aws_secrets = getAWS_Secrets()
-        return c.aws_secrets
+	if c.aws_secrets != nil {
+		return c.aws_secrets
+	}
+	c.aws_secrets = getAWSSecrets()
+	return c.aws_secrets
 }
-
 
 func exists(path string) (bool, error) {
 	_, err := os.Stat(path)
@@ -123,52 +122,52 @@ func add(arg1, arg2 int) int {
 }
 
 func concat(args ...string) (s string) {
-    s = ""
-    for _, v := range args {
-        s = s + v
-    }
-    return
+	s = ""
+	for _, v := range args {
+		s = s + v
+	}
+	return
 }
 
 func sequence(firstS, lastS string) []string {
-    // return a sequence of strings from first to last (inclusive)
-    // `sequence 3 5` returns ["3", "4", "5"]
-    first, _ := strconv.Atoi(firstS)
-    last, _ := strconv.Atoi(lastS)
+	// return a sequence of strings from first to last (inclusive)
+	// `sequence 3 5` returns ["3", "4", "5"]
+	first, _ := strconv.Atoi(firstS)
+	last, _ := strconv.Atoi(lastS)
 
-    if last < first {
-        last, first = 0, 0
-    }
-    sequence := make([]string, (last - first + 1))
+	if last < first {
+		last, first = 0, 0
+	}
+	sequence := make([]string, (last - first + 1))
 
-    for i := 0; i + first <= last; i++ {
-        sequence[i] = strconv.Itoa(i + first)
-    }
-    return sequence
+	for i := 0; i+first <= last; i++ {
+		sequence[i] = strconv.Itoa(i + first)
+	}
+	return sequence
 }
 
 var funcMap = template.FuncMap{
-        "contains": contains,
-        "exists":   exists,
-        "split":    strings.Split,
-        "replace":  strings.Replace,
-        "default":  defaultValue,
-        "parseUrl": parseUrl,
-        "atoi":     strconv.Atoi,
-        "add":      add,
-        "concat":   concat,
-        "sequence": sequence,
-        "N":        sequence,
-        "getenv":   GetEnv,
-    }
+	"contains": contains,
+	"exists":   exists,
+	"split":    strings.Split,
+	"replace":  strings.Replace,
+	"default":  defaultValue,
+	"parseUrl": parseUrl,
+	"atoi":     strconv.Atoi,
+	"add":      add,
+	"concat":   concat,
+	"sequence": sequence,
+	"N":        sequence,
+	"getenv":   GetEnv,
+}
+
 //
 // Execute the string_template under the TemplateContext, and
 // return the result as a string
 //
 func string_template_eval(string_template string) string {
 	var result bytes.Buffer
-    t := template.New("String Template").Funcs(funcMap)
-
+	t := template.New("String Template").Funcs(funcMap)
 
 	t, err := t.Parse(string_template)
 	if err != nil {
@@ -225,4 +224,3 @@ func generateFile(templatePath, destPath string) bool {
 
 	return true
 }
-

--- a/template.go
+++ b/template.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TemplateContext struct {
-	env, secrets map[string]string
+	env, secrets, aws_secrets map[string]string
 }
 
 func GetEnvMap() map[string]string {
@@ -56,6 +56,15 @@ func (c *TemplateContext) Secret() map[string]string {
 	c.secrets = getSecrets()
 	return c.secrets
 }
+
+func (c *TemplateContext) AWS_Secret() map[string]string {
+        if c.aws_secrets != nil {
+                return c.aws_secrets
+        }
+        c.aws_secrets = getAWS_Secrets()
+        return c.aws_secrets
+}
+
 
 func exists(path string) (bool, error) {
 	_, err := os.Stat(path)


### PR DESCRIPTION
Prevent rate-limiting on the DescribeParameters API call. Instead use the GetParametersByPath API call, which is suitable for automated processes.